### PR TITLE
chore(release): publish 1.53.15

### DIFF
--- a/examples/sandbox/package.json
+++ b/examples/sandbox/package.json
@@ -31,5 +31,5 @@
     "clean": "rm -rf dist node_modules public .parcel-cache",
     "dev": "yarn parcel index.html"
   },
-  "version": "1.53.14"
+  "version": "1.53.15"
 }

--- a/integration/package.json
+++ b/integration/package.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "@keepkey/hdwallet-core": "1.53.14",
-    "@keepkey/hdwallet-keepkey": "1.53.14",
-    "@keepkey/hdwallet-keepkey-nodewebusb": "1.53.14",
-    "@keepkey/hdwallet-keepkey-tcp": "1.53.14",
+    "@keepkey/hdwallet-core": "1.53.15",
+    "@keepkey/hdwallet-keepkey": "1.53.15",
+    "@keepkey/hdwallet-keepkey-nodewebusb": "1.53.15",
+    "@keepkey/hdwallet-keepkey-tcp": "1.53.15",
     "@keepkey/hdwallet-native": "1.53.9",
     "fast-json-stable-stringify": "^2.1.0",
     "msw": "^0.27.1",
@@ -18,5 +18,5 @@
     "dev": "lerna run test --scope integration --parallel --include-filtered-dependencies",
     "test": "yarn jest --verbose"
   },
-  "version": "1.53.14"
+  "version": "1.53.15"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "5.2.0",
-  "version": "1.53.14",
+  "version": "1.53.15",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/hdwallet-core/package.json
+++ b/packages/hdwallet-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keepkey/hdwallet-core",
-  "version": "1.53.14",
+  "version": "1.53.15",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/hdwallet-keepkey-chromeusb/package.json
+++ b/packages/hdwallet-keepkey-chromeusb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keepkey/hdwallet-keepkey-chromeusb",
-  "version": "1.53.14",
+  "version": "1.53.15",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -14,7 +14,7 @@
     "prepublishOnly": "yarn clean && yarn build"
   },
   "dependencies": {
-    "@keepkey/hdwallet-core": "1.53.14",
-    "@keepkey/hdwallet-keepkey": "1.53.14"
+    "@keepkey/hdwallet-core": "1.53.15",
+    "@keepkey/hdwallet-keepkey": "1.53.15"
   }
 }

--- a/packages/hdwallet-keepkey-electron/package.json
+++ b/packages/hdwallet-keepkey-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keepkey/hdwallet-keepkey-electron",
-  "version": "1.53.14",
+  "version": "1.53.15",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -14,7 +14,7 @@
     "prepublishOnly": "yarn clean && yarn build"
   },
   "dependencies": {
-    "@keepkey/hdwallet-keepkey": "1.53.14",
+    "@keepkey/hdwallet-keepkey": "1.53.15",
     "uuid": "^8.3.2"
   },
   "peerDependencies": {

--- a/packages/hdwallet-keepkey-nodehid/package.json
+++ b/packages/hdwallet-keepkey-nodehid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keepkey/hdwallet-keepkey-nodehid",
-  "version": "1.53.14",
+  "version": "1.53.15",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -14,7 +14,7 @@
     "prepublishOnly": "yarn clean && yarn build"
   },
   "dependencies": {
-    "@keepkey/hdwallet-keepkey": "1.53.14"
+    "@keepkey/hdwallet-keepkey": "1.53.15"
   },
   "peerDependencies": {
     "node-hid": "^2.1.1"

--- a/packages/hdwallet-keepkey-nodewebusb/package.json
+++ b/packages/hdwallet-keepkey-nodewebusb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keepkey/hdwallet-keepkey-nodewebusb",
-  "version": "1.53.14",
+  "version": "1.53.15",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -14,8 +14,8 @@
     "prepublishOnly": "yarn clean && yarn build"
   },
   "dependencies": {
-    "@keepkey/hdwallet-core": "1.53.14",
-    "@keepkey/hdwallet-keepkey": "1.53.14"
+    "@keepkey/hdwallet-core": "1.53.15",
+    "@keepkey/hdwallet-keepkey": "1.53.15"
   },
   "peerDependencies": {
     "usb": "^2.3.1"

--- a/packages/hdwallet-keepkey-tcp/package.json
+++ b/packages/hdwallet-keepkey-tcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keepkey/hdwallet-keepkey-tcp",
-  "version": "1.53.14",
+  "version": "1.53.15",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -14,8 +14,8 @@
     "prepublishOnly": "yarn clean && yarn build"
   },
   "dependencies": {
-    "@keepkey/hdwallet-core": "1.53.14",
-    "@keepkey/hdwallet-keepkey": "1.53.14",
+    "@keepkey/hdwallet-core": "1.53.15",
+    "@keepkey/hdwallet-keepkey": "1.53.15",
     "axios": "^0.21.1"
   }
 }

--- a/packages/hdwallet-keepkey-webusb/package.json
+++ b/packages/hdwallet-keepkey-webusb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keepkey/hdwallet-keepkey-webusb",
-  "version": "1.53.14",
+  "version": "1.53.15",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -14,8 +14,8 @@
     "prepublishOnly": "yarn clean && yarn build"
   },
   "dependencies": {
-    "@keepkey/hdwallet-core": "1.53.14",
-    "@keepkey/hdwallet-keepkey": "1.53.14"
+    "@keepkey/hdwallet-core": "1.53.15",
+    "@keepkey/hdwallet-keepkey": "1.53.15"
   },
   "devDependencies": {
     "@types/w3c-web-usb": "^1.0.4"

--- a/packages/hdwallet-keepkey/package.json
+++ b/packages/hdwallet-keepkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keepkey/hdwallet-keepkey",
-  "version": "1.53.14",
+  "version": "1.53.15",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -18,7 +18,7 @@
     "@ethereumjs/common": "^2.4.0",
     "@ethereumjs/tx": "^3.3.0",
     "@keepkey/device-protocol": "^7.13.2",
-    "@keepkey/hdwallet-core": "1.53.9",
+    "@keepkey/hdwallet-core": "^1.53.15",
     "@keepkey/proto-tx-builder": "^0.9.0",
     "@metamask/eth-sig-util": "^7.0.0",
     "@shapeshiftoss/bitcoinjs-lib": "5.2.0-shapeshift.2",

--- a/packages/hdwallet-native-vault/package.json
+++ b/packages/hdwallet-native-vault/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keepkey/hdwallet-native-vault",
-  "version": "1.53.14",
+  "version": "1.53.15",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/hdwallet-native/package.json
+++ b/packages/hdwallet-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keepkey/hdwallet-native",
-  "version": "1.53.14",
+  "version": "1.53.15",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Hdwallet-keepkey had a legacy -core package hard coded in its package.json.

 This pr brings all packages to the same version number.

I believe its still a bug lerna is failing to bump it. 