### PR TITLE
Update jQuery to version 4

### DIFF
--- a/examples/sandbox/package.json
+++ b/examples/sandbox/package.json
@@ -9,7 +9,7 @@
     "@pioneer-platform/pioneer-coins": "^9.11.11",
     "bip32": "^2.0.4",
     "eip-712": "^1.0.0",
-    "jquery": "^3.7.1",
+    "jquery": "^4.0.0",
     "json": "^9.0.6",
     "p-queue": "^7.4.1",
     "parcel": "^2.11.0",
@@ -17,7 +17,7 @@
     "web3": "^1.5.1"
   },
   "devDependencies": {
-    "@types/jquery": "^3.5.22",
+    "@types/jquery": "^4.0.0",
     "https-browserify": "^1.0.0",
     "os-browserify": "^0.3.0",
     "path-browserify": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3951,12 +3951,10 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
-"@types/jquery@^3.5.22":
-  version "3.5.29"
-  resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.5.29.tgz#3c06a1f519cd5fc3a7a108971436c00685b5dcea"
-  integrity sha512-oXQQC9X9MOPRrMhPHHOsXqeQDnWeCDT3PelUIg/Oy8FAbzSZtFHRjc7IpbfFVmpLtJ+UOoywpRsuO5Jxjybyeg==
-  dependencies:
-    "@types/sizzle" "*"
+"@types/jquery@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-4.0.0.tgz#b7717b6e5103b50b115b707950357f302cc92fba"
+  integrity sha512-Z+to+A2VkaHq1DfI2oSwsoCdhCHMpTSgjWzNcbNlRGYzksDBpPUgEcAL+RQjOBJRaLoEAOHXxqDGBVP+BblBwg==
 
 "@types/js-levenshtein@^1.1.0":
   version "1.1.3"
@@ -4094,11 +4092,6 @@
   integrity sha512-+ge/loa0oTozxip6zmhRIk8Z/boU51wl9Q6QdLZcokIGMzY5lFXYy/x7Htj2HTC6/KZP1hUbZ1ekx8DYXICvWg==
   dependencies:
     "@types/node" "*"
-
-"@types/sizzle@*":
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.8.tgz#518609aefb797da19bf222feb199e8f653ff7627"
-  integrity sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -9243,10 +9236,10 @@ jose@^4.3.5:
   resolved "https://registry.yarnpkg.com/jose/-/jose-4.15.4.tgz#02a9a763803e3872cf55f29ecef0dfdcc218cc03"
   integrity sha512-W+oqK4H+r5sITxfxpSU+MMdr/YSWGvgZMQDIsNoBDGGy4i7GBPTtvFKibQzW06n3U3TqHjhvBJsirShsEJ6eeQ==
 
-jquery@^3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.1.tgz#083ef98927c9a6a74d05a6af02806566d16274de"
-  integrity sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==
+jquery@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-4.0.0.tgz#95c33ac29005ff72ec444c5ba1cf457e61404fbb"
+  integrity sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==
 
 js-levenshtein@^1.1.6:
   version "1.1.6"


### PR DESCRIPTION
## Fixes #17 

## Summary

- Upgrade jQuery from 3.x to 4.x in `examples/sandbox`
- Update `jquery` and `@types/jquery` to ^4.0.0
- Fixes #17

## Testing

- [ ] Not run (explain why)
- [x] Tests passed locally
- [ ] Added/updated tests

## Checklist

- [x] Linked issue or rationale provided
- [ ] Docs updated (if needed)
- [ ] Breaking change noted in `changelog.md` (if needed)