### PR TITLE
fix: register Osmosis and Binance in transport typeRegistry

### DIFF
--- a/packages/hdwallet-keepkey/src/typeRegistry.ts
+++ b/packages/hdwallet-keepkey/src/typeRegistry.ts
@@ -1,8 +1,10 @@
 import * as Messages from "@keepkey/device-protocol/lib/messages_pb";
+import * as BinanceMessages from "@keepkey/device-protocol/lib/messages-binance_pb";
 import * as CosmosMessages from "@keepkey/device-protocol/lib/messages-cosmos_pb";
 import * as EosMessages from "@keepkey/device-protocol/lib/messages-eos_pb";
 import * as MayachainMessages from "@keepkey/device-protocol/lib/messages-mayachain_pb";
 import * as NanoMessages from "@keepkey/device-protocol/lib/messages-nano_pb";
+import * as OsmosisMessages from "@keepkey/device-protocol/lib/messages-osmosis_pb";
 import * as RippleMessages from "@keepkey/device-protocol/lib/messages-ripple_pb";
 import * as ThorchainMessages from "@keepkey/device-protocol/lib/messages-thorchain_pb";
 import * as ZcashMessages from "@keepkey/device-protocol/lib/messages-zcash_pb";
@@ -18,7 +20,9 @@ function omit(obj: Record<string, any>, ...keys: string[]): Record<string, any> 
 
 const AllMessages = ([] as Array<[string, core.Constructor<jspb.Message>]>)
   .concat(Object.entries(omit(Messages, "MessageType", "MessageTypeMap")))
+  .concat(Object.entries(BinanceMessages))
   .concat(Object.entries(CosmosMessages))
+  .concat(Object.entries(OsmosisMessages))
   .concat(Object.entries(RippleMessages))
   .concat(Object.entries(NanoMessages))
   .concat(Object.entries(omit(EosMessages, "EosPublicKeyKind", "EosPublicKeyKindMap")))


### PR DESCRIPTION
## Summary
- Add `OsmosisMessages` and `BinanceMessages` to the transport type registry
- Without this, device responses for Osmosis (type 1101) and Binance are not deserializable — the transport fakes a `FAILURE("Unknown message type received")` even though the firmware handles these chains correctly

## Root cause
`typeRegistry.ts` builds `messageTypeRegistry` from `AllMessages`, which concatenates all proto modules. Osmosis and Binance proto modules were imported in their respective chain files (`osmosis.ts`, `binance.ts`) for *sending* messages, but never added to `AllMessages` — so *response* types couldn't be deserialized.

Cosmos, THORChain, Mayachain, Ripple, EOS, Nano, Zcash were all registered. Solana/TON/TRON self-register via side-effect functions. Osmosis and Binance were the gap.

## Test plan
- [ ] `osmosisGetAddress()` returns address instead of FAILURE
- [ ] `binanceGetAddress()` returns address instead of FAILURE
- [ ] Existing chains unaffected (no duplicate registrations)