### PR TITLE
fix: register Ethereum and Tendermint in transport typeRegistry

### DIFF
--- a/packages/hdwallet-keepkey/src/typeRegistry.ts
+++ b/packages/hdwallet-keepkey/src/typeRegistry.ts
@@ -2,10 +2,12 @@ import * as Messages from "@keepkey/device-protocol/lib/messages_pb";
 import * as BinanceMessages from "@keepkey/device-protocol/lib/messages-binance_pb";
 import * as CosmosMessages from "@keepkey/device-protocol/lib/messages-cosmos_pb";
 import * as EosMessages from "@keepkey/device-protocol/lib/messages-eos_pb";
+import * as EthereumMessages from "@keepkey/device-protocol/lib/messages-ethereum_pb";
 import * as MayachainMessages from "@keepkey/device-protocol/lib/messages-mayachain_pb";
 import * as NanoMessages from "@keepkey/device-protocol/lib/messages-nano_pb";
 import * as OsmosisMessages from "@keepkey/device-protocol/lib/messages-osmosis_pb";
 import * as RippleMessages from "@keepkey/device-protocol/lib/messages-ripple_pb";
+import * as TendermintMessages from "@keepkey/device-protocol/lib/messages-tendermint_pb";
 import * as ThorchainMessages from "@keepkey/device-protocol/lib/messages-thorchain_pb";
 import * as ZcashMessages from "@keepkey/device-protocol/lib/messages-zcash_pb";
 import * as core from "@keepkey/hdwallet-core";
@@ -22,10 +24,12 @@ const AllMessages = ([] as Array<[string, core.Constructor<jspb.Message>]>)
   .concat(Object.entries(omit(Messages, "MessageType", "MessageTypeMap")))
   .concat(Object.entries(BinanceMessages))
   .concat(Object.entries(CosmosMessages))
+  .concat(Object.entries(EthereumMessages))
   .concat(Object.entries(OsmosisMessages))
   .concat(Object.entries(RippleMessages))
   .concat(Object.entries(NanoMessages))
   .concat(Object.entries(omit(EosMessages, "EosPublicKeyKind", "EosPublicKeyKindMap")))
+  .concat(Object.entries(TendermintMessages))
   .concat(Object.entries(ThorchainMessages))
   .concat(Object.entries(MayachainMessages))
   .concat(Object.entries(ZcashMessages));


### PR DESCRIPTION
## Summary
- Add `EthereumMessages` and `TendermintMessages` to the transport type registry
- Fixes ETH signing operations (`signTx`, `signMessage`, `signTypedData`) which silently fail because the transport can't deserialize device responses

## Root cause
Same class of bug as #33 (Osmosis/Binance). The Ethereum proto module (`messages-ethereum_pb`) was imported in `ethereum.ts` for sending messages but never added to `AllMessages` in `typeRegistry.ts`. Device responses (`EthereumAddress`=57, `EthereumTxRequest`=59, `EthereumMessageSignature`=110, `EthereumTypedDataSignature`=113) couldn't be deserialized — the transport fabricates `FAILURE("Unknown message type received")`.

## Why ETH appeared to work
`EvmAddressManager.initialize()` wraps `ethGetAddress()` in `try { } catch { continue }` (evm-addresses.ts:170), silently swallowing the deserialization failure. Addresses load from SQLite cache instead. But **signing has no such fallback** — `ethSignTx()` fails outright when the device responds with `EthereumTxRequest` (type 59).

## Verified
Built and tested the compiled registry — all response types now resolve:
```
  57 (EthereumAddress): ✓
  59 (EthereumTxRequest): ✓
  110 (EthereumMessageSignature): ✓
  113 (EthereumTypedDataSignature): ✓
  1001 (TendermintAddress): ✓
  1003 (TendermintMsgRequest): ✓
  1006 (TendermintSignedTx): ✓
```

## Coverage after this PR + #33
All 14 proto modules are now registered:

| Module | Registration |
|--------|-------------|
| messages_pb (core) | `AllMessages` (always was) |
| Binance | `AllMessages` (#33) |
| Cosmos | `AllMessages` (always was) |
| EOS | `AllMessages` (always was) |
| **Ethereum** | **`AllMessages` (this PR)** |
| Mayachain | `AllMessages` (always was) |
| Nano | `AllMessages` (always was) |
| Osmosis | `AllMessages` (#33) |
| Ripple | `AllMessages` (always was) |
| **Tendermint** | **`AllMessages` (this PR)** |
| Thorchain | `AllMessages` (always was) |
| Zcash | `AllMessages` (always was) |
| Solana | Self-registers (`solana.ts`) |
| TRON | Self-registers (`tron.ts`) |
| TON | Self-registers (`ton.ts`) |

## Test plan
- [ ] `ethGetAddress()` returns address (not FAILURE)
- [ ] `ethSignTx()` completes signing flow (EthereumTxRequest deserialized)
- [ ] `ethSignMessage()` returns signature
- [ ] `ethSignTypedData()` returns signature
- [ ] Existing chains unaffected