### PR TITLE
fix: register Osmosis + Ethereum in transport typeRegistry

### DIFF
--- a/packages/hdwallet-keepkey/src/typeRegistry.ts
+++ b/packages/hdwallet-keepkey/src/typeRegistry.ts
@@ -1,8 +1,10 @@
 import * as Messages from "@keepkey/device-protocol/lib/messages_pb";
 import * as CosmosMessages from "@keepkey/device-protocol/lib/messages-cosmos_pb";
 import * as EosMessages from "@keepkey/device-protocol/lib/messages-eos_pb";
+import * as EthereumMessages from "@keepkey/device-protocol/lib/messages-ethereum_pb";
 import * as MayachainMessages from "@keepkey/device-protocol/lib/messages-mayachain_pb";
 import * as NanoMessages from "@keepkey/device-protocol/lib/messages-nano_pb";
+import * as OsmosisMessages from "@keepkey/device-protocol/lib/messages-osmosis_pb";
 import * as RippleMessages from "@keepkey/device-protocol/lib/messages-ripple_pb";
 import * as ThorchainMessages from "@keepkey/device-protocol/lib/messages-thorchain_pb";
 import * as ZcashMessages from "@keepkey/device-protocol/lib/messages-zcash_pb";
@@ -19,6 +21,8 @@ function omit(obj: Record<string, any>, ...keys: string[]): Record<string, any> 
 const AllMessages = ([] as Array<[string, core.Constructor<jspb.Message>]>)
   .concat(Object.entries(omit(Messages, "MessageType", "MessageTypeMap")))
   .concat(Object.entries(CosmosMessages))
+  .concat(Object.entries(EthereumMessages))
+  .concat(Object.entries(OsmosisMessages))
   .concat(Object.entries(RippleMessages))
   .concat(Object.entries(NanoMessages))
   .concat(Object.entries(omit(EosMessages, "EosPublicKeyKind", "EosPublicKeyKindMap")))


### PR DESCRIPTION
## Summary
- Transport's `fromMessageBuffer()` fabricated fake `Failure("Unknown message type received")` for Osmosis responses because `OsmosisMessages` wasn't in the `AllMessages` array in `typeRegistry.ts`
- The device responded correctly to `OsmosisGetAddress` (type 1100) but the transport couldn't deserialize the `OsmosisAddress` response (type 1101) — no constructor registered
- Same gap for `EthereumMessages` (needed for EthereumTxMetadata responses in clear-signing flow)
- Solana, Tron, TON already self-register via hand-rolled classes in their respective files

## Test plan
- [ ] `wallet.osmosisGetAddress()` returns a valid `osmo1...` address on firmware 7.10.0+
- [ ] `wallet.cosmosGetAddress()` still works (regression check)
- [ ] Ethereum signing with metadata responses deserialize correctly