### PR TITLE
fix(keepkey): validate Features version fields in initialize() before semver

### DIFF
--- a/packages/hdwallet-keepkey/src/keepkey-initialize.test.ts
+++ b/packages/hdwallet-keepkey/src/keepkey-initialize.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for KeepKeyHDWallet.initialize() version-field validation.
+ *
+ * Regression: when transport.call() returns a Features payload missing
+ * majorVersion / minorVersion / patchVersion (e.g. wrong message type
+ * miscast, decode mismatch, or device in an unexpected state), the prior
+ * code constructed `vundefined.undefined.undefined` and called
+ * semver.gte() on it, which threw the opaque error
+ *   "Invalid Version: vundefined.undefined.undefined"
+ * leaking from the WebUSB pair path with no actionable diagnostic.
+ *
+ * The fix throws a clear error before reaching semver.
+ */
+import { KeepKeyHDWallet } from "./keepkey";
+
+function makeMockTransport(callResponse: any) {
+  return {
+    debugLink: false,
+    call: jest.fn().mockResolvedValue(callResponse),
+    getDeviceID: jest.fn().mockResolvedValue("mock-device-id"),
+    keyring: { addAlias: jest.fn() },
+  } as any;
+}
+
+describe("KeepKeyHDWallet.initialize() version-field validation", () => {
+  it("throws a clear error when Features has no version fields", async () => {
+    const transport = makeMockTransport({
+      message: {
+        deviceId: "mock-device-id",
+        // majorVersion / minorVersion / patchVersion intentionally absent
+      },
+    });
+    const wallet = new KeepKeyHDWallet(transport);
+
+    await expect(wallet.initialize()).rejects.toThrow(
+      /KeepKey Initialize returned Features without firmware version/
+    );
+    await expect(wallet.initialize()).rejects.toThrow(
+      /major=undefined, minor=undefined, patch=undefined/
+    );
+  });
+
+  it("throws when only majorVersion is missing", async () => {
+    const transport = makeMockTransport({
+      message: {
+        deviceId: "mock-device-id",
+        minorVersion: 14,
+        patchVersion: 0,
+      },
+    });
+    const wallet = new KeepKeyHDWallet(transport);
+    await expect(wallet.initialize()).rejects.toThrow(
+      /KeepKey Initialize returned Features without firmware version/
+    );
+  });
+
+  it("does NOT throw the version-validation error when all version fields are present", async () => {
+    const transport = makeMockTransport({
+      message: {
+        deviceId: "mock-device-id",
+        majorVersion: 7,
+        minorVersion: 14,
+        patchVersion: 0,
+      },
+    });
+    const wallet = new KeepKeyHDWallet(transport);
+
+    // initialize() may still throw downstream (e.g. coin support setup) since
+    // we're using a stub Features. We only assert the validation error is NOT
+    // present — the version check has passed.
+    let err: any;
+    try {
+      await wallet.initialize();
+    } catch (e) {
+      err = e;
+    }
+    if (err) {
+      expect(String(err.message ?? err)).not.toMatch(
+        /KeepKey Initialize returned Features without firmware version/
+      );
+      expect(String(err.message ?? err)).not.toMatch(/Invalid Version/);
+    }
+  });
+
+  it("regression: never produces 'Invalid Version: vundefined.undefined.undefined'", async () => {
+    const transport = makeMockTransport({
+      message: { deviceId: "mock-device-id" },
+    });
+    const wallet = new KeepKeyHDWallet(transport);
+    let err: any;
+    try {
+      await wallet.initialize();
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect(String(err.message ?? err)).not.toMatch(
+      /Invalid Version: vundefined\.undefined\.undefined/
+    );
+  });
+});

--- a/packages/hdwallet-keepkey/src/keepkey-initialize.test.ts
+++ b/packages/hdwallet-keepkey/src/keepkey-initialize.test.ts
@@ -32,12 +32,10 @@ describe("KeepKeyHDWallet.initialize() version-field validation", () => {
     });
     const wallet = new KeepKeyHDWallet(transport);
 
-    await expect(wallet.initialize()).rejects.toThrow(
-      /KeepKey Initialize returned Features without firmware version/
-    );
-    await expect(wallet.initialize()).rejects.toThrow(
-      /major=undefined, minor=undefined, patch=undefined/
-    );
+    const err = await wallet.initialize().catch((e: any) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toMatch(/KeepKey Initialize returned Features without firmware version/);
+    expect(err.message).toMatch(/major=undefined, minor=undefined, patch=undefined/);
   });
 
   it("throws when only majorVersion is missing", async () => {
@@ -54,7 +52,7 @@ describe("KeepKeyHDWallet.initialize() version-field validation", () => {
     );
   });
 
-  it("does NOT throw the version-validation error when all version fields are present", async () => {
+  it("resolves successfully when all version fields are present", async () => {
     const transport = makeMockTransport({
       message: {
         deviceId: "mock-device-id",
@@ -65,21 +63,11 @@ describe("KeepKeyHDWallet.initialize() version-field validation", () => {
     });
     const wallet = new KeepKeyHDWallet(transport);
 
-    // initialize() may still throw downstream (e.g. coin support setup) since
-    // we're using a stub Features. We only assert the validation error is NOT
-    // present — the version check has passed.
-    let err: any;
-    try {
-      await wallet.initialize();
-    } catch (e) {
-      err = e;
-    }
-    if (err) {
-      expect(String(err.message ?? err)).not.toMatch(
-        /KeepKey Initialize returned Features without firmware version/
-      );
-      expect(String(err.message ?? err)).not.toMatch(/Invalid Version/);
-    }
+    const features = await wallet.initialize();
+    expect(features).toBeDefined();
+    expect(features.majorVersion).toBe(7);
+    expect(features.minorVersion).toBe(14);
+    expect(features.patchVersion).toBe(0);
   });
 
   it("regression: never produces 'Invalid Version: vundefined.undefined.undefined'", async () => {

--- a/packages/hdwallet-keepkey/src/keepkey.ts
+++ b/packages/hdwallet-keepkey/src/keepkey.ts
@@ -1187,6 +1187,24 @@ export class KeepKeyHDWallet implements core.HDWallet, core.BTCWallet, core.ETHW
       this.transport.keyring.addAlias(transportDeviceID, out.deviceId);
     }
 
+    // Validate version fields BEFORE constructing the semver string. Without this,
+    // a Features response missing major/minor/patch (e.g. wrong message type cast,
+    // device in an unexpected state, or runtime decode mismatch) produces
+    // `vundefined.undefined.undefined`, which semver.gte() rejects with the opaque
+    // error "Invalid Version: vundefined.undefined.undefined". Surface a clear
+    // diagnostic instead so callers can recognize the failure mode.
+    if (
+      typeof out.majorVersion !== "number" ||
+      typeof out.minorVersion !== "number" ||
+      typeof out.patchVersion !== "number"
+    ) {
+      throw new Error(
+        `KeepKey Initialize returned Features without firmware version ` +
+        `(major=${out.majorVersion}, minor=${out.minorVersion}, patch=${out.patchVersion}). ` +
+        `Device may be in bootloader mode, mid-update, or returned an unexpected message type.`
+      );
+    }
+
     const fwVersion = `v${out.majorVersion}.${out.minorVersion}.${out.patchVersion}`;
     //Lost Support per proto 44.3
     this._supportsOsmosis = semver.gte(fwVersion, "v7.7.0");


### PR DESCRIPTION
## Summary

`KeepKeyHDWallet.initialize()` constructs the firmware version string from the protobuf `Features` response and immediately passes it to `semver.gte()` to populate the coin-support feature flags:

```ts
const fwVersion = `v${out.majorVersion}.${out.minorVersion}.${out.patchVersion}`;
this._supportsOsmosis = semver.gte(fwVersion, "v7.7.0");
```

If any of `majorVersion` / `minorVersion` / `patchVersion` are `undefined` (wrong-message-type miscast, decode mismatch, device in an unexpected state, etc.), the code happily produces:

```
vundefined.undefined.undefined
```

…and `semver.gte()` then throws the opaque error:

```
Invalid Version: vundefined.undefined.undefined
```

This bubbles up through `pairRawDevice()` with no actionable diagnostic, which has been observed leaking from the WebUSB pair path in **KeepKey Vault on Windows** as a silent splash hang on first launch — there's no clue in the engine log that the failure is a malformed `Features` response.

## Fix

Add a guard in `initialize()` that validates the three version fields are numbers **before** constructing `fwVersion`. On failure, throw a clear runtime error that names the missing fields:

```
KeepKey Initialize returned Features without firmware version (major=undefined, minor=undefined, patch=undefined). Device may be in bootloader mode, mid-update, or returned an unexpected message type.
```

Consumers (KeepKey Vault engine controller, etc.) can now recognize this failure mode and surface a meaningful UI state instead of crashing or hanging.

## Tests

New file `packages/hdwallet-keepkey/src/keepkey-initialize.test.ts` with **4 tests**:

1. Throws clear error when Features has no version fields
2. Throws when only `majorVersion` is missing
3. Does **not** throw the validation error when all version fields are present
4. Regression: never produces `Invalid Version: vundefined.undefined.undefined`

The tests use a hand-rolled mock transport (`call`, `getDeviceID`, `keyring.addAlias`, `debugLink`) — no USB hardware required.

### Verified locally

| Step | Result |
|---|---|
| `yarn build` (`tsc --build`) | clean |
| New tests against **unfixed** code | 3 fail with `"Invalid Version: vundefined.undefined.undefined"` (exact match for the original bug string) |
| New tests against **fixed** code | 4/4 pass |
| Full `hdwallet-keepkey` suite | 13/13 pass (9 baseline + 4 new) |
| `yarn lint:ts` (`tsc --noEmit`) | clean |

## Scope

Strictly defensive — no behavioral change for any code path where the device returns a properly populated `Features`. The fix only affects the previously-undiagnosable `vundefined.undefined.undefined` failure mode.

## Test plan

- [x] Unit tests pass (`yarn jest --testPathPattern keepkey-initialize`)
- [x] Existing tests still pass (`yarn jest --testPathPattern hdwallet-keepkey`)
- [x] TypeScript typecheck clean (`yarn lint:ts`)
- [ ] Reviewer: skim the new error message wording for consistency with project tone