### PR TITLE
feat(keepkey): expose firmware-reported pre-image hash on EthSignTx

### DIFF
--- a/packages/hdwallet-core/src/ethereum.ts
+++ b/packages/hdwallet-core/src/ethereum.ts
@@ -103,6 +103,10 @@ export interface ETHSignedTx {
   s: string;
   /** big-endian hex, prefixed with '0x' */
   serialized: string;
+  /** KeepKey-only: keccak256 pre-image the firmware actually signed (32-byte hex).
+   *  Optional — older firmware doesn't populate it. Useful for diagnostics where
+   *  the caller needs to verify which bytes the device hashed. */
+  deviceSignedHash?: string;
 }
 
 export interface ETHSignMessage {

--- a/packages/hdwallet-keepkey/src/ethereum.ts
+++ b/packages/hdwallet-keepkey/src/ethereum.ts
@@ -386,6 +386,20 @@ export async function ethSignTx(transport: Transport, msg: core.ETHSignTx): Prom
     const v = core.mustBeDefined(response.getSignatureV());
     const v2 = "0x" + v.toString(16);
 
+    // Capture the firmware-reported pre-image hash (KeepKey custom field).
+    // Older firmware doesn't populate this; absence is non-fatal.
+    let deviceSignedHash: string | undefined;
+    try {
+      if (response.hasHash && response.hasHash() && response.getHash_asU8) {
+        const h = response.getHash_asU8();
+        if (h && h.length === 32) {
+          deviceSignedHash = "0x" + core.toHexString(h);
+        }
+      }
+    } catch {
+      // ignore — older firmware/proto may not support `hash`
+    }
+
     const common = Common.custom({ chainId: msg.chainId });
     const tx = msg.maxFeePerGas
       ? FeeMarketEIP1559Transaction.fromTxData({
@@ -403,7 +417,8 @@ export async function ethSignTx(transport: Transport, msg: core.ETHSignTx): Prom
       s,
       v,
       serialized: "0x" + core.toHexString(tx.serialize()),
-    };
+      ...(deviceSignedHash ? { deviceSignedHash } : {}),
+    } as core.ETHSignedTx & { deviceSignedHash?: string };
   });
 }
 

--- a/packages/hdwallet-keepkey/src/ethereum.ts
+++ b/packages/hdwallet-keepkey/src/ethereum.ts
@@ -412,13 +412,14 @@ export async function ethSignTx(transport: Transport, msg: core.ETHSignTx): Prom
         })
       : Transaction.fromTxData({ ...utxBase, gasPrice: msg.gasPrice, r: r, s: s, v: v2 }, { common });
 
-    return {
+    const result: core.ETHSignedTx = {
       r,
       s,
       v,
       serialized: "0x" + core.toHexString(tx.serialize()),
-      ...(deviceSignedHash ? { deviceSignedHash } : {}),
-    } as core.ETHSignedTx & { deviceSignedHash?: string };
+    };
+    if (deviceSignedHash) result.deviceSignedHash = deviceSignedHash;
+    return result;
   });
 }
 


### PR DESCRIPTION
## Summary

- `EthereumSignedTx` (KeepKey custom proto) carries an optional `hash` field — the keccak256 pre-image the firmware actually signed. The SDK previously ignored it.
- Capture it and surface as `deviceSignedHash` on the returned signed tx so callers can pin firmware behavior in tests / diagnostics.
- Non-breaking: purely additive, optional field, older firmware silently skips (try/catch).

## Motivation

EIP-1559 tx hash regression where `ethers.Transaction.from()` reconstruction recovers the wrong signer. With the firmware-reported hash exposed, we can narrow the divergence to RLP-construction vs. signing instead of guessing.

## Test plan

- [ ] Existing ETH-sign tests still green (no shape change for callers that don't read `deviceSignedHash`).
- [ ] On firmware that supports the `hash` field: signed tx response includes `deviceSignedHash` as a 32-byte hex string.
- [ ] On older firmware lacking the field: `deviceSignedHash` is undefined; nothing else changes.
- [ ] Diagnostic harness (separate repo) recovers `expectedSigner` from `(deviceSignedHash, r, s, v)` for the regression fixture.