### PR TITLE
fix(zcash): unbreak master CI — prettier wrap + jest/no-conditional-expect

### DIFF
--- a/packages/hdwallet-keepkey/src/zcash.test.ts
+++ b/packages/hdwallet-keepkey/src/zcash.test.ts
@@ -38,6 +38,7 @@ describe("zcashSignPczt", () => {
       calls.push(mtype);
 
       if (calls.length === 1) {
+        // eslint-disable-next-line jest/no-conditional-expect
         expect(mtype).toBe(Messages.MessageType.MESSAGETYPE_ZCASHSIGNPCZT);
         const ack = new ZcashMessages.ZcashPCZTActionAck();
         ack.setNextIndex(0);
@@ -50,7 +51,11 @@ describe("zcashSignPczt", () => {
 
       if (calls.length >= 2 && calls.length <= 4) {
         const expectedInputIndex = calls.length - 2;
+        // The mock implements a protocol state-machine; per-step assertions
+        // here verify the host sent the right message at the right time.
+        // eslint-disable-next-line jest/no-conditional-expect
         expect(mtype).toBe(Messages.MessageType.MESSAGETYPE_ZCASHTRANSPARENTINPUT);
+        // eslint-disable-next-line jest/no-conditional-expect
         expect(msg.getIndex()).toBe(expectedInputIndex);
 
         const sig = new ZcashMessages.ZcashTransparentSig();

--- a/packages/hdwallet-keepkey/src/zcash.ts
+++ b/packages/hdwallet-keepkey/src/zcash.ts
@@ -192,15 +192,21 @@ export async function zcashSignPczt(
 
       for (let signedCount = 0; signedCount < nTransparentInputs; signedCount++) {
         if (inputIndex === 0xff) {
-          throw new Error(`zcash: device finished transparent inputs after ${signedCount}, expected ${nTransparentInputs}`);
+          throw new Error(
+            `zcash: device finished transparent inputs after ${signedCount}, expected ${nTransparentInputs}`
+          );
         }
         if (inputIndex >= nTransparentInputs) {
-          throw new Error(`zcash: device requested transparent input ${inputIndex}, only ${nTransparentInputs} provided`);
+          throw new Error(
+            `zcash: device requested transparent input ${inputIndex}, only ${nTransparentInputs} provided`
+          );
         }
 
         const input = transparentInputs[inputIndex];
         if (input.index !== inputIndex) {
-          throw new Error(`zcash: transparent input descriptor index mismatch: requested ${inputIndex}, got ${input.index}`);
+          throw new Error(
+            `zcash: transparent input descriptor index mismatch: requested ${inputIndex}, got ${input.index}`
+          );
         }
 
         const inputMsg = new ZcashMessages.ZcashTransparentInput();
@@ -228,7 +234,9 @@ export async function zcashSignPczt(
         const nextIndex = sigResp.hasNextIndex() ? sigResp.getNextIndex() : signedCount + 1;
         if (signedCount < nTransparentInputs - 1) {
           if (nextIndex === 0xff) {
-            throw new Error(`zcash: device finished transparent inputs after ${signedCount + 1}, expected ${nTransparentInputs}`);
+            throw new Error(
+              `zcash: device finished transparent inputs after ${signedCount + 1}, expected ${nTransparentInputs}`
+            );
           }
           inputIndex = nextIndex ?? signedCount + 1;
         } else if (nextIndex !== undefined && nextIndex !== 0xff) {


### PR DESCRIPTION
## Summary

Master CI has been red since d83a65c3 (`fix(zcash): stream transparent shield inputs`). Two issue classes:

- **4× prettier/prettier** in `zcash.ts` — long template literals on a single line; auto-fixed by `eslint --fix` (line-wrap inside template).
- **3× jest/no-conditional-expect** in `zcash.test.ts` — the mock implements a protocol state-machine and asserts per-step that the host sent the right message at the right time. Refactoring to top-level assertions would reshape the test; preserved per-step semantics with targeted disable comments.

No behavior change. Confirmed `yarn lint` clean locally.

## Test plan

- [ ] CI green
- [ ] No test logic affected; existing `zcash.test.ts` cases still cover the same behavior