### PR TITLE
feat(ripple): forward memo to device for THORChain XRP swap routing

### DIFF
--- a/packages/hdwallet-keepkey/src/ripple.ts
+++ b/packages/hdwallet-keepkey/src/ripple.ts
@@ -26,6 +26,9 @@ export async function rippleSignTx(transport: Transport, msg: core.RippleSignTx)
     if (msg.payment.destinationTag !== undefined) payment.setDestinationTag(parseInt(msg.payment.destinationTag));
     signTx.setPayment(payment);
 
+    const memo = msg.tx.value.memo;
+    if (memo && memo.trim() && memo.trim() !== ' ') signTx.setMemo(memo.trim());
+
     const resp = await transport.call(Messages.MessageType.MESSAGETYPE_RIPPLESIGNTX, signTx, {
       msgTimeout: core.LONG_TIMEOUT,
       omitLock: true,


### PR DESCRIPTION
## Summary
- Forward `tx.value.memo` to `RippleSignTx` protobuf when signing XRP transactions

## Problem
The vault's XRP tx builder correctly parses THORChain swap memos and stores them in `tx.value.memo`, but `rippleSignTx()` in hdwallet-keepkey never called `setMemo()` on the protobuf message. The memo was dropped before reaching the device, so the firmware never included it in the signed XRPL transaction.

## Change
One line in `packages/hdwallet-keepkey/src/ripple.ts`:
```typescript
const memo = msg.tx.value.memo;
if (memo && memo.trim() && memo.trim() !== ' ') signTx.setMemo(memo.trim());
```

## Dependencies
- `BitHighlander/device-protocol feat/xrp-memo-thorchain` — `RippleSignTx` proto must have field 7 (`memo`)
- `BitHighlander/keepkey-firmware feat/xrp-memo-thorchain` — firmware must serialize the memo into XRPL Memos array

## Test plan
- [ ] XRP send without memo: works as before, no Memos field in serialized tx
- [ ] XRP send with numeric memo: still routes to destinationTag (handled in vault's xrp.ts)
- [ ] THORChain swap: memo `=:ETH.ETH:0x...` appears in device confirmation and is serialized into tx