### PR TITLE
fix(nodehid): accept PID 0x0002 (firmware 7.x) in HID adapter

### DIFF
--- a/packages/hdwallet-keepkey-nodehid/src/adapter.ts
+++ b/packages/hdwallet-keepkey-nodehid/src/adapter.ts
@@ -2,7 +2,7 @@ import * as keepkey from "@keepkey/hdwallet-keepkey";
 import * as hid from "node-hid";
 
 import { Device, TransportDelegate } from "./transport";
-import { PRODUCT_ID, VENDOR_ID } from "./utils";
+import { PRODUCT_ID, PRODUCT_ID_WEBUSB, VENDOR_ID } from "./utils";
 
 export const HIDKeepKeyAdapterDelegate = {
   async inspectDevice(device: Device) {
@@ -17,7 +17,7 @@ export const HIDKeepKeyAdapterDelegate = {
   },
   async getDevices(): Promise<Device[]> {
     return (hid.devices().filter((d) => d.path !== undefined && d.serialNumber !== undefined) as Device[]).filter(
-      (d) => d.vendorId === VENDOR_ID && d.productId === PRODUCT_ID
+      (d) => d.vendorId === VENDOR_ID && (d.productId === PRODUCT_ID || d.productId === PRODUCT_ID_WEBUSB)
     );
   },
   async getDevice(serialNumber?: string): Promise<Device> {

--- a/packages/hdwallet-keepkey-nodehid/src/utils.ts
+++ b/packages/hdwallet-keepkey-nodehid/src/utils.ts
@@ -1,2 +1,3 @@
 export const VENDOR_ID = 0x2b24;
 export const PRODUCT_ID = 0x0001;
+export const PRODUCT_ID_WEBUSB = 0x0002; // firmware 7.x — HID interface still accessible when USB is OS-blocked


### PR DESCRIPTION
## Problem

`hdwallet-keepkey-nodehid` filtered `hid.devices()` for `PRODUCT_ID = 0x0001` only. Firmware 7.x devices use `PRODUCT_ID = 0x0002`.

When WebUSB is OS-blocked (`LIBUSB_ERROR_ACCESS` on macOS/Linux — missing udev rules, macOS IOKit claiming the interface, etc.), HID is the intended fallback transport. But HID silently returned "device not found" for any 0x0002 device, causing the vault to loop through 24 retry attempts with no working transport.

The `hdwallet-keepkey-nodewebusb` adapter already accepts both PIDs — this patch brings `nodehid` in line with it.

## Changes

- `utils.ts`: export `PRODUCT_ID_WEBUSB = 0x0002`
- `adapter.ts`: filter accepts either `PRODUCT_ID` or `PRODUCT_ID_WEBUSB`

## Test plan

- Connect a firmware 7.x KeepKey (PID 0x0002) on a system where WebUSB is blocked
- Vault should pair via HID fallback instead of looping to exhaustion