### PR TITLE
fix(nodewebusb): drop legacy PID 0x0001 from WebUSB getDevice filter

### DIFF
--- a/packages/hdwallet-keepkey-nodewebusb/src/adapter.ts
+++ b/packages/hdwallet-keepkey-nodewebusb/src/adapter.ts
@@ -10,10 +10,14 @@ export const NodeWebUSBAdapterDelegate = {
     return devices.filter((x) => x.vendorId === VENDOR_ID && [WEBUSB_PRODUCT_ID, HID_PRODUCT_ID].includes(x.productId));
   },
   async getDevice(serialNumber?: string): Promise<Device> {
+    // Only match the WebUSB PID (0x0002). The TransportDelegate ctor rejects any
+    // other PID with FirmwareUpdateRequired, so matching legacy 0x0001 here just
+    // produced a doomed pair attempt + a misleading "Firmware 6.1.0 required"
+    // before the caller's HID fallback. Old (PID 0x0001) devices now skip WebUSB
+    // cleanly and pair over HID. (getDevices() still lists 0x0001 for detection.)
     const out = await webusb.requestDevice({
       filters: [
         { vendorId: VENDOR_ID, productId: WEBUSB_PRODUCT_ID, serialNumber },
-        { vendorId: VENDOR_ID, productId: HID_PRODUCT_ID, serialNumber },
       ],
     });
     if (out.serialNumber === undefined) throw new Error("expected serial number");


### PR DESCRIPTION
## Problem
Users with old (2019-era, PID `0x0001`) KeepKeys report failures connecting to update — including a misleading **"Firmware 6.1.0 or later is required"** path, and confusion around "device connected to another device."

## Root cause
The WebUSB adapter's `getDevice()` filter matched **both** `WEBUSB_PRODUCT_ID` (`0x0002`) and the legacy `HID_PRODUCT_ID` (`0x0001`). But the `TransportDelegate` constructor rejects any non-`0x0002` PID with `FirmwareUpdateRequired("KeepKey", "6.1.0")`. So WebUSB can **never** serve a `0x0001` device — matching it in the active pair filter only produced a doomed WebUSB attempt and a misleading firmware-update error *before* the caller's HID fallback ran.

## Fix
Remove `0x0001` from the `getDevice` request filter. Old devices now skip WebUSB cleanly and pair over HID (the transport they actually need). `getDevices()` (passive enumeration) still lists `0x0001` for detection, so device-present signaling is unaffected.

## Notes
- No behavior change for modern `0x0002` devices.
- The genuine "connected to another device" case is `claimInterface` code-19 → `ConflictingApp` (real contention), unchanged by this PR.

## Test plan
- [ ] **Old PID 0x0001 device**: connect → pairs via HID without the "Firmware 6.1.0 required" error; firmware update flow proceeds.
- [ ] Modern PID 0x0002 device: connect/update unchanged.
- [ ] Device-detected (on-bus) signaling still works for an old device.

⚠️ Needs verification on real 0x0001 hardware before merge. Consumer (keepkey-vault) requires a submodule-pointer bump after this merges.