### PR TITLE
fix(nodehid): use async read() so device Cancel can dispatch

### DIFF
--- a/packages/hdwallet-keepkey-nodehid/src/transport.ts
+++ b/packages/hdwallet-keepkey-nodehid/src/transport.ts
@@ -37,8 +37,14 @@ export class TransportDelegate implements keepkey.TransportDelegate {
 
   async readChunk(): Promise<Uint8Array> {
     if (!(await this.isOpened())) throw new Error("cannot read from a closed connection");
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const result = await this.hidRef!.readSync();
+    // node-hid's async read() runs on a background thread, unlike readSync() which
+    // blocks the JS event loop for the entire time the device waits for a button
+    // press — that freeze prevented the concurrent cancelDeviceSigning RPC from ever
+    // dispatching, so an on-device Cancel (e.g. from the swap flow) could never fire.
+    const result = await new Promise<number[]>((resolve, reject) => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this.hidRef!.read((err, data) => (err ? reject(err) : resolve(data)));
+    });
     return new Uint8Array(result);
   }
 


### PR DESCRIPTION
On the HID transport, `TransportDelegate.readChunk()` used node-hid `readSync()`, which blocks the JS event loop for the entire time the device waits for a button press. Because the loop is frozen, no concurrent RPC handler (e.g. `cancelDeviceSigning` → `wallet.cancel()`) can dispatch until signing finishes — so sending an on-device `Cancel` was impossible on HID. This is the root cause of the vault swap flow's Cancel button not aborting the device.

Fix: read via node-hid's async `read(callback)`, which runs on a background thread and keeps the event loop free. Same one-report-per-call semantics; `new Uint8Array(number[])` unchanged.

WebUSB and emulator transports were already non-blocking, so this only affected the HID fallback.