### PR TITLE
fix(keepkey): require prevout/script fields on Zcash transparent inputs

### DIFF
--- a/packages/hdwallet-keepkey/src/zcash.test.ts
+++ b/packages/hdwallet-keepkey/src/zcash.test.ts
@@ -293,6 +293,56 @@ describe("zcashSignPczt — shield tx (1 output, 1 input, 2 actions)", () => {
     expect(result._transparentSignatures).toHaveLength(1);
   });
 
+  it("rejects snake_case transparent input fields before sending to the device", async () => {
+    // A caller passing sidecar-shaped keys (prevout_txid/script_pubkey) must
+    // fail loudly host-side — the old behaviour silently omitted the fields
+    // and the device rejected with "Invalid transparent input data".
+    const calls: number[] = [];
+    const call = jest.fn().mockImplementation((mtype: number) => {
+      calls.push(mtype);
+      if (mtype === Messages.MessageType.MESSAGETYPE_ZCASHSIGNPCZT) {
+        const ack = new ZcashMessages.ZcashTransparentAck();
+        ack.setNextOutputIndex(0);
+        return Promise.resolve({
+          message_enum: Messages.MessageType.MESSAGETYPE_ZCASHTRANSPARENTACK,
+          message_type: "ZcashTransparentAck",
+          proto: ack,
+        });
+      }
+      if (mtype === Messages.MessageType.MESSAGETYPE_ZCASHTRANSPARENTOUTPUT) {
+        const ack = new ZcashMessages.ZcashTransparentAck();
+        ack.setNextInputIndex(0);
+        return Promise.resolve({
+          message_enum: Messages.MessageType.MESSAGETYPE_ZCASHTRANSPARENTACK,
+          message_type: "ZcashTransparentAck",
+          proto: ack,
+        });
+      }
+      throw new Error(`unexpected call: ${mtype}`);
+    });
+
+    const snakeCaseRequest = {
+      ...SHIELD_REQUEST,
+      transparent_inputs: [
+        {
+          index: 0,
+          addressNList: SHIELD_REQUEST.transparent_inputs[0].addressNList,
+          amount: 4008918,
+          prevout_txid: "ca3a5ef0323760c97406564a0eb51239ca1afa4944e968af78084d70982c13df",
+          prevout_index: 1,
+          sequence: 0xffffffff,
+          script_pubkey: "76a9149ef6ee0267fd387526020c265a470e2dad7f3b5e88ac",
+        } as any,
+      ],
+    };
+
+    await expect(zcashSignPczt(makeMockTransport(call), snakeCaseRequest, SIGHASH)).rejects.toThrow(
+      /missing prevoutTxid/
+    );
+    // The gutted ZcashTransparentInput must never have been sent
+    expect(calls).not.toContain(Messages.MessageType.MESSAGETYPE_ZCASHTRANSPARENTINPUT);
+  });
+
   it("shielded-only (no transparent) goes directly to ZcashPCZTActionAck", async () => {
     const calls: number[] = [];
     const call = jest.fn().mockImplementation((mtype: number) => {

--- a/packages/hdwallet-keepkey/src/zcash.ts
+++ b/packages/hdwallet-keepkey/src/zcash.ts
@@ -316,14 +316,24 @@ export async function zcashSignPczt(
             addressNList: input?.addressNList,
           });
 
+          // Firmware rejects an input without prevout/script as "Invalid
+          // transparent input data" — fail loudly host-side instead of
+          // silently sending a gutted message (a snake_case caller would
+          // otherwise pass every one of these as undefined).
+          if (!input.prevoutTxid || input.prevoutIndex === undefined || !input.scriptPubkey) {
+            throw new Error(
+              `zcash: transparent input ${input.index} missing prevoutTxid/prevoutIndex/scriptPubkey (camelCase required)`
+            );
+          }
+
           const inputMsg = new ZcashMessages.ZcashTransparentInput();
           inputMsg.setIndex(input.index);
           inputMsg.setAddressNList(input.addressNList);
           inputMsg.setAmount(input.amount);
-          if (input.prevoutTxid) inputMsg.setPrevoutTxid(hexToBytes(input.prevoutTxid));
-          if (input.prevoutIndex !== undefined) inputMsg.setPrevoutIndex(input.prevoutIndex);
+          inputMsg.setPrevoutTxid(hexToBytes(input.prevoutTxid));
+          inputMsg.setPrevoutIndex(input.prevoutIndex);
           if (input.sequence !== undefined) inputMsg.setSequence(input.sequence);
-          if (input.scriptPubkey) inputMsg.setScriptPubkey(hexToBytes(input.scriptPubkey));
+          inputMsg.setScriptPubkey(hexToBytes(input.scriptPubkey));
 
           response = await transport.call(Messages.MessageType.MESSAGETYPE_ZCASHTRANSPARENTINPUT, inputMsg, {
             msgTimeout: core.LONG_TIMEOUT,


### PR DESCRIPTION
Live-session bug: a caller passing sidecar-shaped snake_case keys (`prevout_txid`/`script_pubkey`) to `zcashSignPczt` had those fields silently dropped by the optional-field guards, so the device received a gutted `ZcashTransparentInput` and rejected every shield transaction with **"Invalid transparent input data"** — after the user had already approved outputs on-device.

## Fix
- `zcashSignPczt` now throws host-side, naming the missing camelCase fields (`prevoutTxid`/`prevoutIndex`/`scriptPubkey`), before any message reaches the device.
- `setPrevoutTxid`/`setPrevoutIndex`/`setScriptPubkey` are now unconditional — the validation above guarantees presence.

## Tests
New regression test feeds a snake_case-shaped request and asserts it rejects with `missing prevoutTxid` **without** a `ZcashTransparentInput` ever being sent (the transport mock records every message type). 5/5 in `zcash.test.ts` — the suite whose header comment declares exactly this key-name-mismatch class as its purpose.

Verified end-to-end on-device: with the paired vault fix (keepkey/keepkey-vault#368) a shield tx signs and broadcasts; with a deliberately snake_case request the throw fires before device contact.

Note for merge: please use a **merge commit** (not squash) — keepkey/keepkey-vault#368 pins submodule gitlink `e343b223`, which must remain reachable from master.